### PR TITLE
Refactor to allow CLI options and fix the server not accepting a custom port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Maya-Kai ( மாய கை )
 
 A way to mirror gestures and user interactions in ReactNative applications.
-Useful for testing apps on devices with different screen sizes at the same time - just interact with one device and all other devices follow the interactions. 
+Useful for testing apps on devices with different screen sizes at the same time - just interact with one device and all other devices follow the interactions.
 Can also be used for recording and then replaying user interactions.
 
-ReactNative uses React's EventPluginHub and this module adds an additional plugin to listen to events and send them to a server. The server broadcasts these events to all other connected clients, enabling mirroring of gestures. 
+ReactNative uses React's EventPluginHub and this module adds an additional plugin to listen to events and send them to a server. The server broadcasts these events to all other connected clients, enabling mirroring of gestures.
 
 ## Usage
 1. Install the package using `npm install maya-kai` inside your ReactNative applications
 
-2. _Server _- Start the server at port 8082 using `node_modules/.bin/maya-kai-server`.  Note that this server should be accessible to the device and you may need to do `adb reverse tcp:8082 tcp:8082` for Android. 
+2. _Server _- Start the server at port 8082 using `node_modules/.bin/maya-kai-server`.  Note that this server should be accessible to the device and you may need to do `adb reverse tcp:8082 tcp:8082` for Android.
 
-3. _Client_ - Import and start this module in the ReactNative application's start file - like `index.ios.js` or `index.android.js` using 
+3. _Client_ - Import and start this module in the ReactNative application's start file - like `index.ios.js` or `index.android.js` using
 ```javascript
 import MK from 'maya-kai';
 MK.start();
@@ -23,10 +23,15 @@ MK.start();
 ### API / Options
 __Server__
 
-While the server starts up at port __8082__, this can be changed by passing the port as an option to the server - like `node_modules/.bin/maya-kai-server 8088`.
+By default the server starts on __localhost__ on port __8082__, this can be changed by using the `-p|--port` and `-s|--server` options:
+
+```
+node_modules/.bin/maya-kai-server -s myserver.com -p 8088
+```
 
 __Client__
-If the server is started on a different URL or port, it can be passed to the ReactNative application using 
+
+If the server is started on a different server or port, it can be passed to the ReactNative application using
 
 ```javascript
 import MK from 'maya-kai';
@@ -36,16 +41,16 @@ MK.start('myserver.com:8088').then(successCallback, errorCallback)
 ## Troubleshooting
 If you see a "_Yellow BOX_" warning on the ReactNative application, it means that the app was not able to connect to the Maya-Kai server. Check if you have run `adb reverse`, or are able to access the server URL from a browser on the device.
 
-Note that gesture sync between iOS and Android may be buggy since the internal implementation may not always create the exact Object tree and this, elements may not be present of one of the platforms. 
+Note that gesture sync between iOS and Android may be buggy since the internal implementation may not always create the exact Object tree and elements may not be present on one of the platforms.
 
 ## Utilities
 This modules comes with a set of utilities
 
 ### Record/Replay
-This is a client that lets you record and play back the gestures at a later time. To run this, start the server, add the client code to as described in the usage section. Start the ReactNative app. 
-Then run `node_modules/src/clients/record.js [filename.log]`. Perform actions on the ReactNative app and once you are done, hit `Ctrl+C` on the `record.js` process.
+This is a client that lets you record and play back the gestures at a later time. To run this, start the server, add the client code to as described in the usage section. Start the ReactNative app.
+Then run `node_modules/src/clients/record.js [_actions.log]`. Perform actions on the ReactNative app and once you are done, hit `Ctrl+C` on the `record.js` process.
 
-Then reload the ReactNative app and run `node_modules/src/clients/replay.js [filename.log]`. The replay process will read the actions and send them back to the application.
+Then reload the ReactNative app and run `node_modules/src/clients/replay.js [_actions.log]`. The replay process will read the actions and send them back to the application.
 
 ### Delayed Echo
-The echo client listens to events, and send them back to the same app after a 5 second delay. Can be used to test actions like counters, etc. Typically useful to see if the setup works. 
+The echo client listens to events, and send them back to the same app after a 5 second delay. Can be used to test actions like counters, etc. Typically useful to see if the setup works.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Parashuram <code@nparashuram.com>",
   "license": "MIT",
   "dependencies": {
+    "minimist": "^1.2.0",
     "ws": "^1.1.1"
   }
 }

--- a/src/clients/echo.js
+++ b/src/clients/echo.js
@@ -2,7 +2,7 @@
 
 var WebSocket = require('ws');
 
-var _ = require('./../constants');
+var _ = require('./../config');
 var JSOG = require('./../util/jsog');
 
 var ID = Math.random();

--- a/src/clients/record.js
+++ b/src/clients/record.js
@@ -2,13 +2,13 @@
 var fs = require('fs');
 var WebSocket = require('ws');
 
-var _ = require('./../constants');
+var _ = require('./../config');
 var JSOG = require('./../util/jsog');
 
 var ID = Math.random();
 var startTime = new Date().getTime();
 
-var filename = process.argv[2] || '_actions.log';
+var filename = _.ARGUMENTS[0] || '_actions.log';
 console.log('Recording actions at ', filename);
 
 fs.writeFileSync(filename, '', 'utf-8');

--- a/src/clients/replay.js
+++ b/src/clients/replay.js
@@ -2,13 +2,13 @@
 var fs = require('fs');
 var WebSocket = require('ws');
 
-var _ = require('./../constants');
+var _ = require('./../config');
 var JSOG = require('./../util/jsog');
 
 var ID = Math.random();
 var startTime = new Date().getTime();
 
-var filename = process.argv[2] || '_actions.log';
+var filename = _.ARGUMENTS[0] || '_actions.log';
 console.log('Replaying actions from ', filename);
 
 var actions = JSON.parse('[' + fs.readFileSync(filename, 'utf-8') + 'null]');

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,22 @@
+var argv = require('minimist')(process.argv.slice(2), {
+    default: {
+        port: 8082,
+        server: 'localhost',
+    },
+    alias: {
+        port: 'p',
+        server: 's',
+    },
+});
+
+module.exports = {
+    // Expose the raw CLI args and options
+    ARGUMENTS: argv['_'],
+    OPTIONS: argv,
+
+    SERVER: argv.server,
+    PORT: argv.port,
+
+    MSG_ID: 'msg_id',
+    MSG_EVENT: 'msg_event'
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,0 @@
-module.exports = {
-    PORT: 8082,
-    SERVER: 'localhost',
-
-    MSG_ID: 'msg_id',
-    MSG_EVENT: 'msg_event'
-}

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import ReactNativeEventEmitter from 'react/lib/ReactNativeEventEmitter';
 
 import JSOG from './util/jsog';
 
-import {SERVER, PORT, MSG_ID, MSG_EVENT} from './constants';
+import {SERVER, PORT, MSG_ID, MSG_EVENT} from './config';
 
 const ID = Math.random();
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,4 @@
-var _ = require('./constants');
+var _ = require('./config');
 var WebSocketServer = require('ws').Server
 
 var wss = new WebSocketServer({ port: _.PORT });


### PR DESCRIPTION
The README states the port the server is ran on "can be changed by passing the port as an option to the server".  However, this does not work.  Upon inspection, I found that the `SERVER` and `PORT` are hard coded in `constants.js`, and these values then used everywhere, thus not allowing you to set the port. Additionally, the `SERVER` should be settable via the CLI.

In light of this, I refactored `constants.js`, and renamed it to `config.js`, since it will no longer contain only constants.  I used the lightweight [minimist](https://www.npmjs.com/package/minimist) package to ease the parsing of the command line arguments.

The server and port can now be set using the new `-p|--port` and `-s|--server` options.  I also exposed the raw command `ARGUMENTS` and `OPTIONS` for use in the built-in clients.

I also updated the README to reflect these changes.
